### PR TITLE
Data attribute namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ If you choose to fork the repo you can build the assets running
 
 Add the instructions to your elements:
 
-`data-intro`: Text to show with the instructions  
-`data-position`: (`left`, `top`, `right`, `bottom`), where to place the text with respect to the element
+`data-chardinjs-intro`: Text to show with the instructions  
+`data-chardinjs-position`: (`left`, `top`, `right`, `bottom`), where to place the text with respect to the element
 
 ```HTML
-<img src="img/chardin.png" data-intro="An awesome 18th-century painter, who found beauty in everyday, common things." data-position="right" />
+<img src="img/chardin.png" data-chardinjs-intro="An awesome 18th-century painter, who found beauty in everyday, common things." data-chardinjs-position="right" />
 ```
 
 ## Running
@@ -56,13 +56,21 @@ change `body` to some other selector.
 $('.container').chardinJs('start')
 ```
 
+The function also accepts an optional second namespace parameter to use in place of "chardinjs". For instance,
+
+```Javascript
+$('body').chardinJs('start', 'namespace')
+```
+
+would target the "data-namespace-intro" and "data-namespace-position" attributes. Pass in an empty string ("") to use "data-intro" and "data-position".
+
 ## Methods
 
-### .chardinJs('start')
+### .chardinJs('start', [namespace])
 
 Start ChardinJs in the selector.
 
-### .chardinJs('toggle')
+### .chardinJs('toggle', [namespace])
 
 Toggle ChardinJs.
 
@@ -93,6 +101,7 @@ Triggered when chardinJs is stopped.
  * [nmeum](https://github.com/nmeum)
  * [Jakob Miland](https://github.com/saebekassebil)
  * [printercu](https://github.com/printercu)
+ * [Mike Chen](https://github.com/mhchen)
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ If you choose to fork the repo you can build the assets running
 
 Add the instructions to your elements:
 
-`data-chardinjs-intro`: Text to show with the instructions  
+`data-chardinjs-text`: Text to show with the instructions  
 `data-chardinjs-position`: (`left`, `top`, `right`, `bottom`), where to place the text with respect to the element
 
 ```HTML
-<img src="img/chardin.png" data-chardinjs-intro="An awesome 18th-century painter, who found beauty in everyday, common things." data-chardinjs-position="right" />
+<img src="img/chardin.png" data-chardinjs-text="An awesome 18th-century painter, who found beauty in everyday, common things." data-chardinjs-position="right" />
 ```
 
 ## Running
@@ -62,7 +62,7 @@ The function also accepts an optional second namespace parameter to use in place
 $('body').chardinJs('start', 'namespace')
 ```
 
-would target the "data-namespace-intro" and "data-namespace-position" attributes. Pass in an empty string ("") to use "data-intro" and "data-position".
+would target the "data-namespace-text" and "data-namespace-position" attributes. Pass in an empty string ("") to use "data-text" and "data-position".
 
 ## Methods
 

--- a/chardinjs.coffee
+++ b/chardinjs.coffee
@@ -121,7 +121,7 @@ do ($ = window.jQuery, window) ->
       @._position_helper_layer element
       @$el.get()[0].appendChild helper_layer
 
-      tooltip_text = element.getAttribute(@._get_data_attribute 'intro')
+      tooltip_text = element.getAttribute(@._get_data_attribute 'text')
       tooltip_layer.className = "chardinjs-tooltip chardinjs-#{tooltip_position}"
       tooltip_layer.innerHTML = "<div class='chardinjs-tooltiptext'>#{tooltip_text}</div>"
       helper_layer.appendChild tooltip_layer
@@ -157,7 +157,7 @@ do ($ = window.jQuery, window) ->
       element_position
 
     _get_elements: () ->
-      @$el.find("*[#{@._get_data_attribute 'intro'}]")
+      @$el.find("*[#{@._get_data_attribute 'text'}]")
 
     _get_data_attribute: (attribute) ->
       data_attribute = 'data-'

--- a/example/index.html
+++ b/example/index.html
@@ -25,15 +25,15 @@
   <body>
     <div class="container">
       <div class="jumbotron">
-        <h1 data-chardinjs-intro="Project title" data-chardinjs-position="right">Chardin.js</h1>
+        <h1 data-chardinjs-text="Project title" data-chardinjs-position="right">Chardin.js</h1>
         <p class="lead">
           Simple overlay instructions for your apps.
         </p>
-        <img src="img/chardin.png" data-chardinjs-intro="An awesome 18th-century painter, who found beauty in everyday, common things." data-chardinjs-position="right" />
-        <a href="#" class="btn btn-large primary" data-toggle="chardinjs" data-chardinjs-intro="This button toggles the overlay, you can click it, even when the overlay is visible" data-chardinjs-position="left">See it in action</a>
+        <img src="img/chardin.png" data-chardinjs-text="An awesome 18th-century painter, who found beauty in everyday, common things." data-chardinjs-position="right" />
+        <a href="#" class="btn btn-large primary" data-toggle="chardinjs" data-chardinjs-text="This button toggles the overlay, you can click it, even when the overlay is visible" data-chardinjs-position="left">See it in action</a>
         <a href="" id="opentour" class="hide" data-toggle="chardinjs">Or open it again</a>
         <div class="credits">
-          <p data-chardinjs-intro="Author of this plugin, aka Pablo Fernandez" data-chardinjs-position="right">
+          <p data-chardinjs-text="Author of this plugin, aka Pablo Fernandez" data-chardinjs-position="right">
             Baked with
             <b>&lt;3</b>
             by
@@ -44,7 +44,7 @@
 
 
         <div class="links">
-          <p id="links" data-chardinjs-intro="Links to Github, Twitter, etc." data-chardinjs-position="top">
+          <p id="links" data-chardinjs-text="Links to Github, Twitter, etc." data-chardinjs-position="top">
             <a href="https://twitter.com/share" class="twitter-share-button" data-lang="en" data-text="Check out Chardin.js, simple overlay instructions for apps, https://heelhook.github.com/chardin.js" data-count="none" data-via="pablo2dot0">Tweet</a>
             <a href="https://twitter.com/pablo2dot0" class="twitter-follow-button" data-show-count="false" data-lang="en">Follow @pablo2dot0</a>
             <iframe style="display: inline-block;" frameborder="no" scrolling="no" height="30px" width="70px" src="http://hnlike.com/upvote.php?link=http%3A%2F%2Fheelhook.github.com&title=Chardin">iframes not supported by your browser</iframe>

--- a/example/index.html
+++ b/example/index.html
@@ -25,15 +25,15 @@
   <body>
     <div class="container">
       <div class="jumbotron">
-        <h1 data-intro="Project title" data-position="right">Chardin.js</h1>
+        <h1 data-chardinjs-intro="Project title" data-chardinjs-position="right">Chardin.js</h1>
         <p class="lead">
           Simple overlay instructions for your apps.
         </p>
-        <img src="img/chardin.png" data-intro="An awesome 18th-century painter, who found beauty in everyday, common things." data-position="right" />
-        <a href="#" class="btn btn-large primary" data-toggle="chardinjs" data-intro="This button toggles the overlay, you can click it, even when the overlay is visible" data-position="left">See it in action</a>
+        <img src="img/chardin.png" data-chardinjs-intro="An awesome 18th-century painter, who found beauty in everyday, common things." data-chardinjs-position="right" />
+        <a href="#" class="btn btn-large primary" data-toggle="chardinjs" data-chardinjs-intro="This button toggles the overlay, you can click it, even when the overlay is visible" data-chardinjs-position="left">See it in action</a>
         <a href="" id="opentour" class="hide" data-toggle="chardinjs">Or open it again</a>
         <div class="credits">
-          <p data-intro="Author of this plugin, aka Pablo Fernandez" data-position="right">
+          <p data-chardinjs-intro="Author of this plugin, aka Pablo Fernandez" data-chardinjs-position="right">
             Baked with
             <b>&lt;3</b>
             by
@@ -44,7 +44,7 @@
 
 
         <div class="links">
-          <p id="links" data-intro="Links to Github, Twitter, etc." data-position="top">
+          <p id="links" data-chardinjs-intro="Links to Github, Twitter, etc." data-chardinjs-position="top">
             <a href="https://twitter.com/share" class="twitter-share-button" data-lang="en" data-text="Check out Chardin.js, simple overlay instructions for apps, https://heelhook.github.com/chardin.js" data-count="none" data-via="pablo2dot0">Tweet</a>
             <a href="https://twitter.com/pablo2dot0" class="twitter-follow-button" data-show-count="false" data-lang="en">Follow @pablo2dot0</a>
             <iframe style="display: inline-block;" frameborder="no" scrolling="no" height="30px" width="70px" src="http://hnlike.com/upvote.php?link=http%3A%2F%2Fheelhook.github.com&title=Chardin">iframes not supported by your browser</iframe>


### PR DESCRIPTION
I set a temporary namespace attribute on the 'chardinJs' jQuery data. It gets overwritten every time the function is called. I just wanted to not have to pass around the namespace variable everywhere. Let me know if you wanted me to go a different approach.

Also, from your comment in the thread I got the notion that I should change the data_-intro attributes to be data_-text attributes, so I did that while I was in there changing things up. Now that I think about it, it's possible you mistyped this attribute in your reply. Please let me know if that is the case too!
