### PR TITLE
IE8 Events

### DIFF
--- a/chardinjs.js
+++ b/chardinjs.js
@@ -67,9 +67,7 @@
           if (document.detachEvent) {
             try {
               document.detachEvent("onkeydown", this._onKeyDown);
-            } catch (e) {
-              this._onKeyDown = function() { /* No Op */ };
-            }
+            } catch (e) {}
           }
         }
         return this.$el.trigger('chardinJs:stop');

--- a/chardinjs.js
+++ b/chardinjs.js
@@ -65,7 +65,11 @@
           window.removeEventListener("keydown", this._onKeyDown, true);
         } else {
           if (document.detachEvent) {
-            document.detachEvent("onkeydown", this._onKeyDown);
+            try {
+              document.detachEvent("onkeydown", this._onKeyDown);
+            } catch (e) {
+              this._onKeyDown = function() { /* No Op */ };
+            }
           }
         }
         return this.$el.trigger('chardinJs:stop');


### PR DESCRIPTION
In some cases the call to "document.detachEvent("onkeydown", this._onKeyDown);" will throw an error in IE8 and prevent the stop event from firing.
