### PR TITLE
Update to example index.html for HTTPS

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -8,7 +8,7 @@
     <meta name="author" content="Pablo Fernandez">
 
     <!-- styles -->
-    <link href='http://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
     <link href="css/bootstrap.min.css" rel="stylesheet">
     <link href="css/demo.css" rel="stylesheet">
 
@@ -16,7 +16,7 @@
 
     <link href="css/bootstrap-responsive.min.css" rel="stylesheet">
 
-    <script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
+    <script src="//code.jquery.com/jquery-1.9.1.min.js"></script>
     <script src="../chardinjs.min.js"></script>
     <script src="js/demo.js"></script>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>


### PR DESCRIPTION
Made fonts & jQuery urls scheme-relative. If you're accessing the example site through HTTPS Google Fonts and jQuery are blocked since they're requested over HTTP, rendering the plugin unusable.
