### PR TITLE
xhtml compatibility fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
     "name": "heelhook/chardin.js",
-    "version": "0.1.3",
     "main": ["chardinjs.min.js", "chardinjs.js"],
     "description": "Simple overlay instructions for your apps.",
     "license": "Apache",

--- a/chardinjs.js
+++ b/chardinjs.js
@@ -85,7 +85,7 @@
         overlay_layer = document.createElement("div");
         styleText = "";
         overlay_layer.className = "chardinjs-overlay";
-        if (this.$el.prop('tagName') === "BODY") {
+        if (this.$el.prop('tagName').toUpperCase() === "BODY") {
           styleText += "top: 0;bottom: 0; left: 0;right: 0;position: fixed;";
           overlay_layer.setAttribute("style", styleText);
         } else {


### PR DESCRIPTION
Uppercase this.$el.prop('tagName') for xhtml compatibility.

Without this fix the overlay doesnt properly cover the page when using xhtml documents.
