### PR TITLE
Ignore node_modules from the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /Chardin.csproj.user
 /Chardin.csproj
 /bundleconfig.json
+/node_modules
 [Bb]in/
 [Oo]bj/
 [Ll]og/


### PR DESCRIPTION
The package depends on `jquery`. Once you run `npm i`, `git` will offer `node_modules` for adding as a new directory. This should be prevented in `.gitignore`.