### PR TITLE
Remove BOM from the CSS stylesheet

### DIFF
--- a/chardinjs.css
+++ b/chardinjs.css
@@ -1,4 +1,4 @@
-﻿.chardinjs-overlay {
+.chardinjs-overlay {
   position: absolute;
   z-index: 9999990;
   background-color: #000;


### PR DESCRIPTION
The BOM prevents concatenating `chardinjs.css` to other stylesheets to simply bundle them.

There  are only ASCII characters in `chardinjs.css`. If there were any non-ASCII characters there, the [UTF-8 encoding would be applied by the default](https://www.w3.org/TR/CSS2/syndata.html#charset) by the browser.

Attempts to fix #117.