### PR TITLE
Allow putting more distance between a vertical tooltip and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Add the instructions to your elements:
 `data-position`: (`left`, `top`, `right`, `bottom`), where to place the text with respect to the element.
 In addition you can alter the relative position of the tooltip text by placing a colon and a percentage value (-100 to 100) after the position text, eg "top:-50". 
 This will slide the tooltip along the length or height of the element away from the centre.
+If you want to increae the distance of the tooltip from the element, you can do it by placing a comma and a percentage value (100, 200, 300, 400 or 500) after the tooltip offset, eg "top:0,200". This will shift the tooltip to be twice farther away from the element than by default.
 
 ```HTML
 <img src="img/chardin.png" data-intro="An awesome 18th-century painter, who found beauty in everyday, common things." data-position="right" />

--- a/chardinjs.js
+++ b/chardinjs.js
@@ -199,9 +199,19 @@
                 else
                     positionString = element.getAttribute('data-position');
 
-                return (positionString == null ? 1 : 1 + parseInt(((_ref = positionString.split(':')) != null ? _ref[1] : void 0) || 0, 10) / 100);
+                return (positionString == null ? 1 : 1 + parseInt(((_ref = positionString.split(':')) != null ? (_ref[1] || '').split(',')[0] : void 0) || 0, 10) / 100);
             };
 
+            chardinJs.prototype._get_position_distance = function (element) {
+                var positionString, _ref;
+                var helpref = element.getAttribute(this.data_attribute);
+                if (helpref[0] == '#' && this.data_helptext[helpref].position)
+                    positionString = this.data_helptext[helpref].position;
+                else
+                    positionString = element.getAttribute('data-position');
+
+                return (positionString == null ? 100 : parseInt(((_ref = positionString.split(':')) != null ? (_ref[1] || '').split(',')[1] : void 0) || 100, 10));
+            };
 
 
             chardinJs.prototype._get_css_attribute = function (element) {
@@ -236,13 +246,18 @@
 
 
             chardinJs.prototype._place_tooltip = function (element, tooltip_layer) {
-                var my_height, offset, position, target_element_position, target_height, target_width, tooltipActualWidth, tooltipMaxWidth, tooltip_layer_position;
+                var my_height, offset, distance, position, target_element_position, target_height, target_width, tooltipActualWidth, tooltipMaxWidth, tooltip_layer_position;
                 tooltip_layer_position = this._get_offset(tooltip_layer);
                 tooltip_layer.style.top = null;
                 tooltip_layer.style.right = null;
                 tooltip_layer.style.bottom = null;
                 tooltip_layer.style.left = null;
                 position = this._get_position(element);
+                distance = this._get_position_distance(element);
+                if (distance) {
+                  tooltip_layer.className += ' chardinjs-distance-' + distance;
+                  distance = (distance / 100) - 1;
+                }
                 switch (position) {
                     case "top":
                     case "bottom":
@@ -253,7 +268,7 @@
                         if (my_width) {
                             $(tooltip_layer).width(my_width);
                         }
-                        return tooltip_layer.style[position] = "-" + tooltip_layer_position.height + "px";
+                        return tooltip_layer.style[position] = "-" + (tooltip_layer_position.height + distance * 30) + "px";
                     case "left":
                     case "right":
                         tooltipMaxWidth = parseFloat(this._getStyle(tooltip_layer, "max-width"));
@@ -266,7 +281,7 @@
                         }
                         tooltip_layer.style.top = "" + ((target_height / 2) * this._get_position_offset(element) - (my_height / 2)) + "px";
                         tooltipActualWidth = parseFloat(this._getStyle(tooltip_layer, "width"));
-                        offset = 185 - (tooltipMaxWidth - tooltipActualWidth);
+                        offset = 185 - (tooltipMaxWidth - tooltipActualWidth) + distance * 30;
                         return tooltip_layer.style[position] = "-" + offset + "px";
                 }
             };

--- a/chardinjs.js
+++ b/chardinjs.js
@@ -254,10 +254,8 @@
                 tooltip_layer.style.left = null;
                 position = this._get_position(element);
                 distance = this._get_position_distance(element);
-                if (distance) {
-                  tooltip_layer.className += ' chardinjs-distance-' + distance;
-                  distance = (distance / 100) - 1;
-                }
+                tooltip_layer.className += ' chardinjs-distance-' + distance;
+                distance = (distance / 100) - 1;
                 switch (position) {
                     case "top":
                     case "bottom":

--- a/chardinjs.scss
+++ b/chardinjs.scss
@@ -1,3 +1,16 @@
+$vertical-distance-list: (
+	"100": 30,
+	"200": 60,
+	"300": 90,
+	"400": 120,
+	"500": 150,
+	"600": 180,
+	"700": 210,
+	"800": 240,
+	"900": 270,
+	"1000": 300
+);
+
 @mixin transition($property) {
 	-webkit-transition: $property;
 	-moz-transition: $property;
@@ -85,16 +98,7 @@
 
 	&.chardinjs-bottom:before, &.chardinjs-top:after {
 		width: 1px;
-		height: 30px;
 		left: 50%;
-	}
-
-	&.chardinjs-bottom:before {
-		top: -30px;
-	}
-
-	&.chardinjs-top:after {
-		bottom: -30px;
 	}
 
 	&.chardinjs-right:before {
@@ -103,6 +107,21 @@
 
 	&.chardinjs-left:after {
 		right: -50px;
+	}
+
+	@each $percent, $offset in $vertical-distance-list {
+		&.chardinjs-bottom.chardinjs-distance-#{$percent}:before,
+		&.chardinjs-top.chardinjs-distance-#{$percent}:after {
+			height: #{$offset}px;
+		}
+
+		&.chardinjs-bottom.chardinjs-distance-#{$percent}:before {
+			top: -#{$offset}px;
+		}
+
+		&.chardinjs-top.chardinjs-distance-#{$percent}:after {
+			bottom: -#{$offset}px;
+		}
 	}
 }
 


### PR DESCRIPTION
Use percent of the default distance (100-500). 100 is the default. Place the value to the position attribute after the offset separated by a comma. For example: `bottom:100,200` will move the pointer line of the helper to the right and the tooltip twice the default distance down.

Attempts to fix #121.